### PR TITLE
Returning number of elements skipped in seek/tail

### DIFF
--- a/ingester/src/integration_test.cpp
+++ b/ingester/src/integration_test.cpp
@@ -58,8 +58,8 @@ void tail_data(shared_ptr<StreamReader> reader) {
     // seen the element right before the EOF. So, there's not too much we can assert on here.
     double element;
     while (reader) {
-        int num_read = reader->Tail(&element);
-        if (num_read < 0) {
+        int num_skipped = reader->Tail(&element);
+        if (num_skipped < 0) {
             LOG(INFO) << "Tail terminating." << endl;
             return;
         }

--- a/src/tests/integration_test.cpp
+++ b/src/tests/integration_test.cpp
@@ -55,8 +55,8 @@ void tail_data(shared_ptr<StreamReader> reader) {
     // seen the element right before the EOF. So, there's not too much we can assert on here.
     double element;
     while (reader) {
-        int num_read = reader->Tail(&element);
-        if (num_read < 0) {
+        int num_skipped = reader->Tail(&element);
+        if (num_skipped < 0) {
             return;
         }
         ASSERT_GE(element, 0);


### PR DESCRIPTION
Returning the number of elements skipped in seek/tail, so that callers
of seek & tail can determine where they're at in the stream.