### PR TITLE
Ensuring total_samples_read() is kept up-to-date with tails/seeks

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -352,7 +352,9 @@ int64_t StreamReader::TailBytes(char *buffer, int timeout_ms, char *key, int64_t
             } else {
                 memcpy(buffer, val_str, len);
             }
-            return current_sample_idx_ - old_sample_index + 1;
+            int64_t num_skipped = current_sample_idx_ - old_sample_index + 1;
+            num_samples_read_ += num_skipped;
+            return num_skipped;
         }
 
         if (eof_str != nullptr) {
@@ -446,6 +448,7 @@ int64_t StreamReader::Seek(const string &key) {
                                      ret,
                                      cursor_.left,
                                      cursor_.right) << endl;
+            num_samples_read_ += ret;
             return ret;
         }
 

--- a/src/tests/integration_test.cpp
+++ b/src/tests/integration_test.cpp
@@ -54,12 +54,15 @@ void tail_data(shared_ptr<StreamReader> reader) {
     // NB: tail() is sorta undefined when there's an EOF inserted on the stream: there's no guarantee that tail() has
     // seen the element right before the EOF. So, there's not too much we can assert on here.
     double element;
+    int64_t total_num_skipped = 0;
     while (reader) {
-        int num_skipped = reader->Tail(&element);
+        int64_t num_skipped = reader->Tail(&element);
         if (num_skipped < 0) {
             return;
         }
         ASSERT_GE(element, 0);
+        total_num_skipped += num_skipped;
+        ASSERT_EQ(total_num_skipped, reader->total_samples_read());
     }
 }
 

--- a/src/tests/reader_test.cpp
+++ b/src/tests/reader_test.cpp
@@ -452,6 +452,7 @@ TEST_F(StreamReaderTest, TestTail_Simple) {
 
     ASSERT_EQ(readout, NUM_ELEMENTS - 1);
     ASSERT_EQ(ret, NUM_ELEMENTS);
+    ASSERT_EQ(r->total_samples_read(), NUM_ELEMENTS);
 }
 
 TEST_F(StreamReaderTest, TestTail_SingleElement) {
@@ -617,16 +618,19 @@ TEST_F(StreamReaderTest, TestSeek) {
     ASSERT_EQ(reader_->Seek("0-0"), 0);
     ASSERT_EQ(reader_->Read(&read, 1), 1);
     ASSERT_EQ(read, 10);
+    ASSERT_EQ(reader_->total_samples_read(), 1);
 
     // Shouldn't change the cursor, again, so read just reads the second element
     ASSERT_EQ(reader_->Seek("0-0"), 0);
     ASSERT_EQ(reader_->Read(&read, 1), 1);
     ASSERT_EQ(read, 11);
+    ASSERT_EQ(reader_->total_samples_read(), 2);
 
     // Seek to the 3rd element (12-0), so the next read should be the 4th (13-0)
     ASSERT_EQ(reader_->Seek("12-0"), 1);
     ASSERT_EQ(reader_->Read(&read, 1), 1);
     ASSERT_EQ(read, 13);
+    ASSERT_EQ(reader_->total_samples_read(), 4);
 
     // Seek to just past the 5th element (14-1), so the next read should be the 6th element (15-0)
     ASSERT_EQ(reader_->Seek("14-1"), 1);
@@ -662,6 +666,9 @@ TEST_F(StreamReaderTest, TestSeek) {
     // Finally, insert an EOF, and try to seek past it.
     write_eof(30, 1, "30-1");
     ASSERT_EQ(reader_->Seek("100-0"), -1);
+
+    // 21 elements inserted in this test
+    ASSERT_EQ(reader_->total_samples_read(), 21);
 }
 
 TEST_F(StreamReaderTest, TestMetadata) {


### PR DESCRIPTION
total_samples_read() is now in sync with tails/seeks, and thus should be
consistent with its position in the stream relative to the start of
consumption.