### PR TITLE
Computing local vs global server clocks optionally (& other fixes)

### DIFF
--- a/cpp/src/reader.cpp
+++ b/cpp/src/reader.cpp
@@ -48,7 +48,11 @@ void StreamReader::Initialize(const std::string &stream_name, int timeout_ms) {
         throw StreamReaderException("first_stream_key an empty std::string!");
     }
     const StreamSchema &tmp = StreamSchema::FromJson(metadata["schema"]);
-    this->local_minus_server_clock_us_ = strtoll(metadata["local_minus_server_clock_us"].c_str(), nullptr, 10);
+    if (metadata.find("local_minus_server_clock_us") != metadata.end()) {
+        this->local_minus_server_clock_us_ = strtoll(metadata["local_minus_server_clock_us"].c_str(), nullptr, 10);
+    } else {
+        this->local_minus_server_clock_us_ = 0;
+    }
     this->initialized_at_us_ = strtoull(metadata["initialized_at_us"].c_str(), nullptr, 10);
 
     this->schema_ = make_shared<StreamSchema>(tmp);

--- a/cpp/src/writer.h
+++ b/cpp/src/writer.h
@@ -58,11 +58,19 @@ public:
      * Initialize this stream for writing. The given stream name must be unique within the Redis used. This
      * initialization puts necessary information (e.g. schemas and timestamps) into redis. Optionally, it can accept
      * an unordered_map of user metadata to put in to Redis atomically.
+     *
+     * Accepts a boolean parameter if the field "local_minus_global_clock_us" is going to be computed when initializing
+     * this stream, computed by multiple round trips between this writer and the Redis server. If true, the stream
+     * metadata & reader will populate the local_minus_global_clock_us field, but note that it takes up to a ~second
+     * (depending on connection latency) to compute this. If false, this will be skipped, and
+     * the initialization time will be in local time, and "local_minus_global_clock_us" will not be set. Setting this
+     * false allows for faster writer initialization.
      */
     void Initialize(const std::string &stream_name,
                     const StreamSchema &schema,
                     const std::unordered_map<std::string, std::string> &user_metadata =
-                    std::unordered_map<std::string, std::string>());
+                    std::unordered_map<std::string, std::string>(),
+                    bool compute_local_minus_global_clock = false);
 
     /**
      * Writes data to the stream. The given data buffer of type DataT will be recast to a raw (e.g. char *) array and


### PR DESCRIPTION
Defaulting to not computing this. Only if needed to calibrate local and server times, i.e. if you're running a writer on a different node than the others and there's no NTP/chrony sync syncing clocks.

Other fixes:
- Allowing a timeout in seconds to be specified within RedisConnection optionally
- Not freeing reply pointers that are NULL