### PR TITLE
Allowing further customization of ingester

### DIFF
--- a/cpp/ingester/src/CMakeLists.txt
+++ b/cpp/ingester/src/CMakeLists.txt
@@ -29,6 +29,15 @@ else()
   SET(PARQUET_LIB parquet)
 endif()
 
+if (NOT TARGET nlohmann_json::nlohmann_json)
+    FetchContent_Declare(
+            json
+            GIT_REPOSITORY    https://github.com/nlohmann/json.git
+            GIT_TAG           v3.10.4
+    )
+    FetchContent_MakeAvailable(json)
+endif()
+
 set(INCLUDE_DIRS
         ${ARROW_INCLUDE_DIR}
         ${PARQUET_INCLUDE_DIR}
@@ -45,6 +54,7 @@ set(LIBRARIES_TO_LINK
         "Boost::thread"
         "glog::glog"
         "hiredis"
+        "nlohmann_json::nlohmann_json"
         arrow_shared
         ${PARQUET_LIB}
 )
@@ -56,7 +66,7 @@ endif()
 
 
 
-set(INGESTER_HEADERS ingester.h ingester_threadpool.h)
+set(INGESTER_HEADERS ingester.h ingester_threadpool.h ingester_settings.h)
 set(INGESTER_SOURCES ingester.cpp)
 
 add_executable(ingester ingester_main.cpp ${INGESTER_HEADERS} ${INGESTER_SOURCES})
@@ -78,7 +88,7 @@ target_compile_options(ingester PUBLIC "$<$<CONFIG:RELEASE>:${MY_CXX_RELEASE_OPT
 
 if (RIVER_BUILD_TESTS)
   set(INGESTER_TEST_HEADERS ingester_test_utils.h)
-  set(INGESTER_TEST_SOURCES ingester_test_main.cpp ingester_test.cpp ingester_threadpool_test.cpp integration_test.cpp)
+  set(INGESTER_TEST_SOURCES ingester_test_main.cpp ingester_test.cpp ingester_threadpool_test.cpp integration_test.cpp ingester_settings_test.cpp)
   add_executable(ingester_test ${INGESTER_HEADERS} ${INGESTER_SOURCES} ${INGESTER_TEST_SOURCES} ${INGESTER_TEST_HEADERS})
   add_dependencies(ingester_test river)
   target_link_libraries(ingester_test PRIVATE ${LIBRARIES_TO_LINK} gtest gtest_main)

--- a/cpp/ingester/src/example_settings/example.json
+++ b/cpp/ingester/src/example_settings/example.json
@@ -1,0 +1,25 @@
+{
+  "stream_settings": [
+    {
+      "stream_name_regex": "some-prefix-.*",
+      "columns_blacklist": [
+        "channel_.*"
+      ]
+    },
+    {
+      "stream_name_regex": "some-prefix-2-.*",
+      "columns_whitelist": [
+        "whitelisted_channels_.*"
+      ],
+      "bytes_per_row_group": 1048576,
+      "minimum_age_seconds_before_deletion": 30
+    },
+    {
+      "stream_name_regex": ".*"
+    }
+  ],
+  "global_settings": {
+    "bytes_per_row_group": 134217728,
+    "minimum_age_seconds_before_deletion": 60
+  }
+}

--- a/cpp/ingester/src/ingester_settings.h
+++ b/cpp/ingester/src/ingester_settings.h
@@ -1,0 +1,146 @@
+//
+// Created by Paul Botros on 11/15/19.
+//
+
+#ifndef PARENT_INGESTER_SETTINGS_H
+#define PARENT_INGESTER_SETTINGS_H
+
+
+#include <vector>
+#include <optional>
+#include <regex>
+#include <algorithm>
+#include <river.h>
+#include <nlohmann/json.hpp>
+
+using json = nlohmann::json;
+
+static const int64_t DEFAULT_BYTES_PER_ROW_GROUP = 134217728LL; // 128MB
+static const int DEFAULT_MINIMUM_AGE_SECONDS_BEFORE_DELETION = 60; // 60s lookback
+
+class StreamIngestionSettings {
+public:
+    StreamIngestionSettings() {}
+
+    StreamIngestionSettings(
+            std::optional<std::vector<std::regex>> columns_blacklist_,
+            std::optional<std::vector<std::regex>> columns_whitelist_,
+            int64_t bytes_per_row_group_,
+            int minimum_age_seconds_before_deletion_) {
+        // Whitelist takes priority over blacklist; see filter below.
+        columns_blacklist = columns_blacklist_;
+        columns_whitelist = columns_whitelist_;
+        bytes_per_row_group = bytes_per_row_group_;
+        minimum_age_seconds_before_deletion = minimum_age_seconds_before_deletion_;
+    }
+
+    std::vector<river::FieldDefinition> Filter(const std::vector<river::FieldDefinition>& fields) const {
+        if (columns_whitelist.has_value()) {
+            return FilterList(fields, columns_whitelist.value(), false);
+        } else if (columns_blacklist.has_value()) {
+            return FilterList(fields, columns_blacklist.value(), true);
+        } else {
+            std::vector<river::FieldDefinition> ret(fields.begin(), fields.end());
+            return ret;
+        }
+    }
+
+    std::optional<std::vector<std::regex>> columns_blacklist;
+    std::optional<std::vector<std::regex>> columns_whitelist;
+    int64_t bytes_per_row_group;
+    int minimum_age_seconds_before_deletion;
+
+
+private:
+    static std::vector<river::FieldDefinition> FilterList(
+            const std::vector<river::FieldDefinition>& fields,
+            const std::vector<std::regex>& list,
+            bool default_value) {
+        std::vector<river::FieldDefinition> ret;
+        for (const auto& field : fields) {
+            bool should_add = default_value;
+            for (const auto &column_whitelist: list) {
+                if (std::regex_match(field.name, column_whitelist)) {
+                    should_add = !should_add;
+                    break;
+                }
+            }
+            if (should_add) {
+                ret.push_back(field);
+            }
+        }
+        return ret;
+    }
+};
+
+static std::vector<std::pair<std::regex, StreamIngestionSettings>> ParseStreamSettingsJson(const json& settings_json) {
+    int64_t bytes_per_row_group_global = DEFAULT_BYTES_PER_ROW_GROUP;
+    int minimum_age_seconds_before_deletion_global = DEFAULT_MINIMUM_AGE_SECONDS_BEFORE_DELETION;
+    if (settings_json.contains("global_settings")) {
+        minimum_age_seconds_before_deletion_global = settings_json.value(
+                "minimum_age_seconds_before_deletion",
+                minimum_age_seconds_before_deletion_global);
+        bytes_per_row_group_global = settings_json.value("bytes_per_row_group", bytes_per_row_group_global);
+    }
+
+    std::vector<std::pair<std::regex, StreamIngestionSettings>> ret;
+    if (!settings_json.contains("stream_settings")) {
+        LOG(WARNING) << "Warning: stream settings was empty. Was that intentional to not consume any streams?"
+                     << std::endl;
+        return ret;
+    }
+
+    for (const json& setting_json : settings_json["stream_settings"]) {
+        std::regex stream_name_regex = setting_json["stream_name_regex"];
+        StreamIngestionSettings settings;
+        if (setting_json.contains("columns_blacklist")) {
+            auto columns_blacklist_str = setting_json["columns_blacklist"].get<std::vector<std::string>>();
+
+            std::vector<std::regex> blacklist(columns_blacklist_str.size());
+            std::transform(
+                    columns_blacklist_str.cbegin(),
+                    columns_blacklist_str.cend(),
+                    blacklist.begin(),
+                    [](const std::string& s) {
+                        return std::regex(s);
+                    });
+            settings.columns_blacklist = blacklist;
+        }
+
+        if (setting_json.contains("columns_whitelist")) {
+            auto columns_whitelist_str = setting_json["columns_whitelist"].get<std::vector<std::string>>();
+            std::vector<std::regex> whitelist(columns_whitelist_str.size());
+            std::transform(
+                    columns_whitelist_str.cbegin(),
+                    columns_whitelist_str.cend(),
+                    whitelist.begin(),
+                    [](const std::string& s) {
+                        return std::regex(s);
+                    });
+            settings.columns_whitelist = whitelist;
+        }
+        settings.bytes_per_row_group = setting_json.value(
+                "bytes_per_row_group", bytes_per_row_group_global);
+        settings.minimum_age_seconds_before_deletion = setting_json.value(
+                "minimum_age_seconds_before_deletion", minimum_age_seconds_before_deletion_global);
+        ret.emplace_back(stream_name_regex, settings);
+    }
+
+    return ret;
+}
+
+static std::vector<std::pair<std::regex, StreamIngestionSettings>> ParseStreamSettingsJson(const std::string& path) {
+    std::ifstream ifs(path);
+    json settings_json = json::parse(ifs);
+    return ParseStreamSettingsJson(settings_json);
+}
+
+static std::vector<std::pair<std::regex, StreamIngestionSettings>> DefaultStreamSettings() {
+    json catchall_stream_setting;
+    catchall_stream_setting["stream_name_regex"] = ".*";
+    json j;
+    j["stream_settings"] = json::array({catchall_stream_setting});
+    return ParseStreamSettingsJson(j);
+}
+
+#endif //PARENT_INGESTER_SETTINGS_H

--- a/cpp/ingester/src/ingester_settings_test.cpp
+++ b/cpp/ingester/src/ingester_settings_test.cpp
@@ -1,0 +1,123 @@
+#include "gtest/gtest.h"
+#include <glog/logging.h>
+#include <boost/filesystem.hpp>
+
+#include "ingester_settings.h"
+
+using namespace std;
+using namespace river;
+
+class IngesterSettingsTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        tmp_directory = (boost::filesystem::temp_directory_path() / boost::filesystem::unique_path())
+                .make_preferred().string();
+        boost::filesystem::create_directory(tmp_directory);
+
+    }
+
+    void TearDown() override {
+        if (!tmp_directory.empty()) {
+            boost::filesystem::remove_all(tmp_directory);
+        }
+    }
+
+    std::vector<river::FieldDefinition> fields(std::initializer_list<std::string> field_names) {
+        std::vector<river::FieldDefinition> ret;
+        for (const auto& field_name : field_names) {
+            ret.emplace_back(field_name, river::FieldDefinition::Type::INT32, 4);
+        }
+        return ret;
+    }
+
+    string stream_name;
+    string tmp_directory;
+    string stream_directory;
+    std::optional<std::vector<std::regex>> settings_columns_whitelist;
+    std::optional<std::vector<std::regex>> settings_columns_blacklist;
+    bool terminated;
+    unique_ptr<internal::Redis> redis;
+};
+
+TEST_F(IngesterSettingsTest, TestSimple) {
+    std::string stream_settings_src = R"(
+{
+    "stream_settings": [
+        {
+            "stream_name_regex": "some-prefix-.*",
+            "columns_blacklist": [
+                "channel_.*"
+            ]
+        },
+        {
+            "stream_name_regex": "some-prefix-2-.*",
+            "columns_whitelist": [
+                "whitelisted_channels_.*"
+            ],
+            "bytes_per_row_group": 1048576,
+            "minimum_age_seconds_before_deletion": 30
+        },
+        {
+            "stream_name_regex": ".*"
+        }
+    ],
+    "global_settings": {
+        "bytes_per_row_group": 134217728,
+        "minimum_age_seconds_before_deletion": 60
+    }
+}
+)";
+    auto settings_filename = (boost::filesystem::path(tmp_directory) / "settings.json").make_preferred().string();
+    {
+        std::ofstream out(settings_filename);
+        out << stream_settings_src;
+        out.close();
+    }
+    auto parsed = ParseStreamSettingsJson(settings_filename);
+    ASSERT_EQ(parsed.size(), 3);
+
+    std::regex stream_name_regex = parsed[0].first;
+    auto settings = parsed[0].second;
+    ASSERT_TRUE(std::regex_match("some-prefix-foobar", stream_name_regex));
+    ASSERT_FALSE(std::regex_match("some-not-matching-prefix", stream_name_regex));
+    ASSERT_FALSE(settings.columns_whitelist.has_value());
+    ASSERT_TRUE(settings.columns_blacklist.has_value());
+    ASSERT_EQ(settings.columns_blacklist.value().size(), 1);
+    ASSERT_EQ(settings.Filter(fields({"channel_011", "chanzzz_011"})).size(), 1);
+    ASSERT_EQ(settings.Filter(fields({"not_matching_011"})).size(), 1);
+    ASSERT_EQ(settings.bytes_per_row_group, 134217728);
+    ASSERT_EQ(settings.minimum_age_seconds_before_deletion, 60);
+
+    settings = parsed[1].second;
+    ASSERT_FALSE(settings.columns_blacklist.has_value());
+    ASSERT_TRUE(settings.columns_whitelist.has_value());
+    ASSERT_EQ(settings.columns_whitelist.value().size(), 1);
+    ASSERT_EQ(settings.Filter(fields({"whitelisted_channels_"})).size(), 1);
+    ASSERT_EQ(settings.Filter(fields({"not_channels_"})).size(), 0);
+    ASSERT_EQ(settings.bytes_per_row_group, 1048576);
+    ASSERT_EQ(settings.minimum_age_seconds_before_deletion, 30);
+
+    settings = parsed[2].second;
+    ASSERT_FALSE(settings.columns_blacklist.has_value());
+    ASSERT_FALSE(settings.columns_whitelist.has_value());
+    ASSERT_EQ(settings.Filter(fields({"anything"})).size(), 1);
+    ASSERT_EQ(settings.Filter(fields({"whatever"})).size(), 1);
+    ASSERT_EQ(settings.bytes_per_row_group, 134217728);
+    ASSERT_EQ(settings.minimum_age_seconds_before_deletion, 60);
+}
+
+TEST_F(IngesterSettingsTest, TestDefault) {
+    auto parsed = DefaultStreamSettings();
+    ASSERT_EQ(parsed.size(), 1);
+
+    std::regex stream_name_regex = parsed[0].first;
+    auto settings = parsed[0].second;
+    ASSERT_TRUE(std::regex_match("anything", stream_name_regex));
+    ASSERT_TRUE(std::regex_match("definitely_anything", stream_name_regex));
+    ASSERT_FALSE(settings.columns_whitelist.has_value());
+    ASSERT_FALSE(settings.columns_blacklist.has_value());
+    ASSERT_EQ(settings.Filter(fields({"channel_011", "chanzzz_011"})).size(), 2);
+    ASSERT_EQ(settings.Filter(fields({"not_matching_011"})).size(), 1);
+    ASSERT_GT(settings.bytes_per_row_group, 0);
+    ASSERT_GT(settings.minimum_age_seconds_before_deletion, 0);
+}

--- a/cpp/ingester/src/integration_test.cpp
+++ b/cpp/ingester/src/integration_test.cpp
@@ -89,14 +89,15 @@ protected:
 
         // Set our stalling timeout as 1 STD above the mean, i.e. ~16% of requests should timeout. In reality, this
         // "stalling" timeout should be much higher, in order to capture streams that haven't been properly terminated.
+        StreamIngestionSettings settings;
+        settings.bytes_per_row_group = 2000 * sizeof(double);
+        settings.minimum_age_seconds_before_deletion = 3;
         ingester_factory = [&] {
             return make_unique<StreamIngester>(
                     connection,
                     tmp_directory,
                     &terminated,
-                    stream_name,
-                    2000,
-                    3,
+                    std::vector<std::pair<std::regex, StreamIngestionSettings>>{{std::regex(stream_name), settings}},
                     (int) MEAN_JITTER_MS + STD_JITTER_MS,
                     1000);
         };

--- a/cpp/src/redis.cpp
+++ b/cpp/src/redis.cpp
@@ -279,7 +279,7 @@ Redis::Xadd(const string &stream_name, initializer_list<pair<string, string>> ke
     return river::internal::Redis::UniqueRedisReplyPtr(reply);
 }
 
-vector<string> Redis::ListStreamNames(const string &stream_filter) {
+vector<string> Redis::ListStreamNames() {
     vector<string> ret;
 
     string cursor = "0";
@@ -287,7 +287,7 @@ vector<string> Redis::ListStreamNames(const string &stream_filter) {
         UniqueRedisReplyPtr reply = UniqueRedisReplyPtr(
                 (redisReply *) redisCommand(_context, "SCAN %s MATCH %s-metadata",
                                             cursor.c_str(),
-                                            stream_filter.empty() ? "*" : stream_filter.c_str()));
+                                            "*"));
         if (reply.get() == nullptr) {
             throw RedisException("SCAN returned null.");
         }

--- a/cpp/src/redis.h
+++ b/cpp/src/redis.h
@@ -153,7 +153,7 @@ public:
         return UniqueRedisReplyPtr(reply);
     }
 
-    std::vector<std::string> ListStreamNames(const std::string &stream_filter);
+    std::vector<std::string> ListStreamNames();
 
     void Unlink(const std::string &stream_key);
 

--- a/cpp/src/schema.h
+++ b/cpp/src/schema.h
@@ -37,7 +37,7 @@ typedef struct FieldDefinition {
     } Type;
     Type type;
 
-    FieldDefinition& operator=(const FieldDefinition& t) = default;
+    FieldDefinition &operator=(const FieldDefinition &t) = default;
 
     FieldDefinition(std::string name_, Type type_, int size_) : name(std::move(name_)), size(size_), type(type_) {}
 } FieldDefinition;


### PR DESCRIPTION
Enabling configuration at a finer level for ingestion of streams. Allows a JSON settings file to be passed on the command line that can give finer-grained control of streams via regexes.

See example_settings/example.json for an example JSON setting file. Defaults to settings that include all streams and has default settings.