### PR TITLE
Improving throughput in stream writing

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -14,6 +14,12 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Mo
 option(RIVER_BUILD_TESTS "Set to ON to build tests" ON)
 option(RIVER_BUILD_INGESTER "Set to ON to build the ingester" OFF)
 option(RIVER_INSTALL "Set to ON to install River (set to OFF if embedding in another project)" ON)
+if (MSVC)
+  option(RIVER_BUILD_REDIS_MODULE "Set to ON to build and install a Redis module used for performance improvements" OFF)
+else()
+  option(RIVER_BUILD_REDIS_MODULE "Set to ON to build and install a Redis module used for performance improvements" ON)
+endif()
+set(RIVER_BUILD_REDIS_MODULE_SERVER_VERSION 7.0.9 CACHE INTERNAL "If building the Redis module, what Redis server version to build against")
 
 add_subdirectory(src)
 

--- a/cpp/src/CMakeLists.txt
+++ b/cpp/src/CMakeLists.txt
@@ -28,6 +28,10 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(fmt hiredis json cxxopts)
 
+# So that we don't include the entire hiredis headers; we just need to icnlude a single file
+configure_file(${hiredis_SOURCE_DIR}/sockcompat.h ${CMAKE_CURRENT_BINARY_DIR}/hiredis_extra/sockcompat.h)
+configure_file(${hiredis_SOURCE_DIR}/sockcompat.c ${CMAKE_CURRENT_BINARY_DIR}/hiredis_extra/sockcompat.c)
+
 # ===== External Dependency: glog
 find_package(glog REQUIRED)
 
@@ -47,13 +51,14 @@ set(LIBRARIES_TO_LINK
         ${ADDITIONAL_LIBRARIES})
 set(LIBRARIES_TO_LINK_PKGCONFIG_OPTIONS "-lglog -lhiredis")
 
-set(RIVER_HEADERS writer.h river.h reader.h redis.h schema.h)
-set(RIVER_SOURCES writer.cpp reader.cpp redis.cpp schema.cpp)
+set(RIVER_HEADERS writer.h river.h reader.h redis.h schema.h redis_writer_commands.h)
+set(RIVER_SOURCES writer.cpp reader.cpp redis.cpp schema.cpp ${CMAKE_CURRENT_BINARY_DIR}/hiredis_extra/sockcompat.c)
 
 add_library(river SHARED ${RIVER_HEADERS} ${RIVER_SOURCES})
 target_compile_features(river PRIVATE cxx_std_17)
 target_link_libraries(river PRIVATE ${LIBRARIES_TO_LINK})
 target_link_libraries(river PUBLIC hiredis)
+target_include_directories(river PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/hiredis_extra)
 
 # Make headers public
 set_target_properties(river PROPERTIES PUBLIC_HEADER "${RIVER_HEADERS}")
@@ -176,4 +181,8 @@ if (RIVER_BUILD_TESTS)
   add_test(NAME river_test COMMAND river_test)
   target_compile_options(river_test PUBLIC "$<$<CONFIG:DEBUG>:${MY_CXX_DEBUG_OPTIONS}>")
   target_compile_options(river_test PUBLIC "$<$<CONFIG:RELEASE>:${MY_CXX_RELEASE_OPTIONS}>")
+endif()
+
+if (RIVER_BUILD_REDIS_MODULE)
+    add_subdirectory(redismodule)
 endif()

--- a/cpp/src/redis_writer_commands.h
+++ b/cpp/src/redis_writer_commands.h
@@ -1,0 +1,103 @@
+//
+// Created by Paul Botros on 8/10/23.
+//
+
+#ifndef RIVER_SRC_REDIS_WRITER_COMMANDS_H_
+#define RIVER_SRC_REDIS_WRITER_COMMANDS_H_
+
+#include <string>
+#include <vector>
+#include <fmt/format.h>
+
+namespace river {
+
+/**
+ * A class tailored towards performant writing of data in StreamWriter.
+ *
+ * Typically, there's a "formatting" step when using Redis. When calling a command, you pass in all of the arguments
+ * to that command, and the hiredis library will format those arguments into one long string, and then send that
+ * over the socket. However, when the command is large -- in our cases, consisting of large amounts of binary data --
+ * this introduces a copy of the data during the formatting step. It so happens that binary strings (or "bulk strings")
+ * are passed over the wire unchanged, so this formatting-specific copy is technically unnecessary.
+ *
+ * This class encapsulates a preformatted redis command and just switches out where we know the big "binary bulk string"
+ * corresponding to our River data to be. In the implementation, we're careful to always put the binary bulk data at
+ * the end of the string. We "switch" out where the bulk string is by simply keeping track of string pointers instead of
+ * actually copying the data.
+ *
+ * This should then be used in conjunction with river::Redis::SendCommandPreformatted.
+ */
+class RedisWriterCommand {
+public:
+    RedisWriterCommand(const std::string &formatted_command) {
+        if (formatted_command[0] != '*') {
+            throw std::invalid_argument("Expected array type for commands!");
+        }
+        auto delimiter_pos = formatted_command.find("\r\n", 1);
+        auto num_array_elements = std::stoi(formatted_command.substr(1, delimiter_pos - 1));
+
+        // Start right after the *[0-9...]\r\n
+        auto formatted_command_pos = delimiter_pos + 2;
+        // Skip until the last command
+        for (int i = 0; i < num_array_elements - 1; i++) {
+            if (formatted_command[formatted_command_pos] != '$') {
+                throw std::invalid_argument("Expected only bulk strings for XADD commands.");
+            }
+            auto delimiter_pos_bulk_string = formatted_command.find("\r\n", formatted_command_pos + 1);
+            auto bulk_string_size =
+                std::stoi(formatted_command.substr(formatted_command_pos + 1,
+                                                   delimiter_pos_bulk_string - formatted_command_pos - 1));
+            formatted_command_pos = delimiter_pos_bulk_string + 2 + bulk_string_size + 2;
+        }
+
+        // Split an entire command into 6 portions, assuming the command is a Redis ARRAY type.
+        // <prefix>, $, <data length>, \r\n, <data>, \r\n
+        // where the prefix is everything up until the start of the last bulk string in the array command.
+        command_parts_.resize(6);
+        command_parts_lens_.resize(6);
+
+        formatted_command_prefix_ = formatted_command.substr(0, formatted_command_pos);
+        command_parts_[0] = formatted_command_prefix_.c_str();
+        command_parts_lens_[0] = formatted_command_prefix_.size();
+
+        command_parts_[1] = "$";
+        command_parts_lens_[1] = 1;
+
+        // Omit #2 which will be the length of the last bulk string
+
+        command_parts_[3] = "\r\n";
+        command_parts_lens_[3] = 2;
+
+        // Omit #4 which will be the actual data
+
+        command_parts_[5] = "\r\n";
+        command_parts_lens_[5] = 2;
+    }
+
+    std::vector<std::pair<const char *, size_t>> ReplaceLastBulkStringAndAssemble(
+        const char *data, size_t data_length) {
+        // Make sure we hold on to this formatted string so it remains allocated
+        formatted_total_size_bytes_ = fmt::format_int(data_length).str();
+        command_parts_[2] = formatted_total_size_bytes_.c_str();
+        command_parts_lens_[2] = formatted_total_size_bytes_.size();
+
+        command_parts_[4] = data;
+        command_parts_lens_[4] = data_length;
+
+        std::vector<std::pair<const char *, size_t>> ret(6);
+        for (int i = 0; i < 6; i++) {
+            ret.emplace_back(command_parts_[i], command_parts_lens_[i]);
+        }
+        return ret;
+    }
+
+private:
+    std::string formatted_command_prefix_;
+    std::string formatted_total_size_bytes_;
+    std::vector<const char *> command_parts_;
+    std::vector<size_t> command_parts_lens_;
+};
+
+}
+
+#endif //RIVER_SRC_REDIS_WRITER_COMMANDS_H_

--- a/cpp/src/redismodule/CMakeLists.txt
+++ b/cpp/src/redismodule/CMakeLists.txt
@@ -1,0 +1,63 @@
+
+# ===== External Dependencies
+include(FetchContent)
+FetchContent_Declare(
+        RedisModulesSDK
+        GIT_REPOSITORY    https://github.com/RedisLabsModules/RedisModulesSDK.git
+        GIT_TAG           7ba899d7b75448e527bcb6f40b1091c5346eac8a
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+)
+
+FetchContent_Declare(
+        redis
+        GIT_REPOSITORY    https://github.com/redis/redis.git
+        GIT_TAG           ${RIVER_BUILD_REDIS_MODULE_SERVER_VERSION}
+        GIT_SHALLOW 1
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+)
+
+FetchContent_MakeAvailable(RedisModulesSDK redis)
+
+
+# So that we don't include the entire redis headers; we just need to icnlude a single file
+configure_file(${redis_SOURCE_DIR}/src/redismodule.h ${CMAKE_CURRENT_BINARY_DIR}/include/redismodule.h)
+add_library(river_redismodule_rmutil
+        STATIC
+        "${redismodulessdk_SOURCE_DIR}/rmutil/util.c"
+        "${redismodulessdk_SOURCE_DIR}/rmutil/strings.c"
+        "${redismodulessdk_SOURCE_DIR}/rmutil/sds.c"
+        "${redismodulessdk_SOURCE_DIR}/rmutil/vector.c"
+        "${redismodulessdk_SOURCE_DIR}/rmutil/alloc.c"
+        "${redismodulessdk_SOURCE_DIR}/rmutil/periodic.c"
+        )
+target_include_directories(river_redismodule_rmutil
+        PRIVATE
+        "${CMAKE_CURRENT_BINARY_DIR}/include"
+        "${redismodulessdk_SOURCE_DIR}/rmutil"
+)
+
+add_library(river_redismodule MODULE
+        river_redismodule.c
+        )
+add_dependencies(river_redismodule river_redismodule_rmutil)
+target_link_libraries(river_redismodule PRIVATE river_redismodule_rmutil)
+target_include_directories(
+        river_redismodule
+        PRIVATE
+        "${CMAKE_CURRENT_BINARY_DIR}/include"
+        "${redismodulessdk_SOURCE_DIR}"
+)
+
+# From https://redis.com/community/redis-modules-hub/how-to-build/
+if(LINUX)
+    target_compile_options(river_redismodule PRIVATE "-fPIC" "-std=gnu99")
+    target_link_options(river_redismodule PRIVATE "-shared" "-Bsymbolic" "-lc")
+elseif(APPLE)
+    target_compile_options(river_redismodule PRIVATE "-dynamic" "-fno-common" "-std=gnu99")
+    target_link_options(river_redismodule PRIVATE "-bundle" "-undefined" "dynamic_lookup" "-lc")
+endif()
+
+install(TARGETS river_redismodule LIBRARY DESTINATION lib)
+

--- a/cpp/src/redismodule/river_redismodule.c
+++ b/cpp/src/redismodule/river_redismodule.c
@@ -1,0 +1,127 @@
+
+#include <redismodule.h>
+
+#include <rmutil/util.h>
+#include <rmutil/strings.h>
+#include <rmutil/test_util.h>
+
+#define ASSERT_NOERROR_STRING_FXN(r) \
+  if ((r) != REDISMODULE_OK) { \
+    return REDISMODULE_ERR; \
+  }
+
+int BatchXaddCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    if (argc != 6) {
+        return RedisModule_WrongArity(ctx);
+    }
+    RedisModule_AutoMemory(ctx);
+
+    // open the key and make sure it's indeed a STREAM
+    RedisModuleKey *key =
+        RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ | REDISMODULE_WRITE);
+    if (RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_STREAM &&
+        RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_EMPTY) {
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+    }
+
+    long long index_start;
+    long long num_samples;
+    long long sample_size_bytes;
+    ASSERT_NOERROR_STRING_FXN(RedisModule_StringToLongLong(argv[2], &index_start));
+    ASSERT_NOERROR_STRING_FXN(RedisModule_StringToLongLong(argv[3], &num_samples));
+    ASSERT_NOERROR_STRING_FXN(RedisModule_StringToLongLong(argv[4], &sample_size_bytes));
+
+    size_t value_length;
+    const char *value = RedisModule_StringPtrLen(argv[5], &value_length);
+
+    RedisModuleString **xadd_params = (RedisModuleString **) RedisModule_Alloc(sizeof(RedisModuleString *) * 4);
+    for (long long i = 0; i < num_samples; i++) {
+        const char *i_str = "i";
+        xadd_params[0] = RedisModule_CreateString(ctx, i_str, strlen(i_str));
+        xadd_params[1] = RedisModule_CreateStringFromLongLong(ctx, index_start + i);
+
+        const char *val_str = "val";
+        xadd_params[2] = RedisModule_CreateString(ctx, val_str, strlen(val_str));
+
+        size_t sample_start = i * sample_size_bytes;
+        xadd_params[3] = RedisModule_CreateString(ctx, &value[sample_start], sample_size_bytes);
+
+        // fields and values;
+        int stream_add_resp = RedisModule_StreamAdd(key, REDISMODULE_STREAM_ADD_AUTOID, NULL, xadd_params, 2);
+        if (stream_add_resp != REDISMODULE_OK) {
+            return RedisModule_ReplyWithError(ctx, "ERR Xadd failed.");
+        }
+
+        for (int j = 0; j < 4; j++) {
+            RedisModule_FreeString(ctx, xadd_params[j]);
+        }
+     }
+    RedisModule_Free(xadd_params);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+int BatchXaddVariableCommand(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    // batch_xadd_variable <key> <index start> <sizes in ints> <value in bytes>
+    if (argc != 5) {
+        return RedisModule_WrongArity(ctx);
+    }
+    RedisModule_AutoMemory(ctx);
+
+    // open the key and make sure it's indeed a STREAM
+    RedisModuleKey *key =
+        RedisModule_OpenKey(ctx, argv[1], REDISMODULE_READ | REDISMODULE_WRITE);
+    if (RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_STREAM &&
+        RedisModule_KeyType(key) != REDISMODULE_KEYTYPE_EMPTY) {
+        return RedisModule_ReplyWithError(ctx, REDISMODULE_ERRORMSG_WRONGTYPE);
+    }
+
+    long long index_start;
+    ASSERT_NOERROR_STRING_FXN(RedisModule_StringToLongLong(argv[2], &index_start));
+
+    size_t sizes_length_raw;
+    const char *sizes_raw = RedisModule_StringPtrLen(argv[3], &sizes_length_raw);
+    const int *sizes = (const int *) sizes_raw;
+    long long num_samples = sizes_length_raw / sizeof(int);
+
+    size_t value_length;
+    const char *value = RedisModule_StringPtrLen(argv[4], &value_length);
+
+    RedisModuleString **xadd_params = (RedisModuleString **) RedisModule_Alloc(sizeof(RedisModuleString *) * 4);
+    size_t sample_start = 0;
+    for (long long i = 0; i < num_samples; i++) {
+        const char *i_str = "i";
+        xadd_params[0] = RedisModule_CreateString(ctx, i_str, strlen(i_str));
+        xadd_params[1] = RedisModule_CreateStringFromLongLong(ctx, index_start + i);
+
+        const char *val_str = "val";
+        xadd_params[2] = RedisModule_CreateString(ctx, val_str, strlen(val_str));
+        xadd_params[3] = RedisModule_CreateString(ctx, &value[sample_start], sizes[i]);
+
+        // fields and values;
+        int stream_add_resp = RedisModule_StreamAdd(key, REDISMODULE_STREAM_ADD_AUTOID, NULL, xadd_params, 2);
+        if (stream_add_resp != REDISMODULE_OK) {
+            return RedisModule_ReplyWithError(ctx, "ERR Xadd failed.");
+        }
+
+        for (int j = 0; j < 4; j++) {
+            RedisModule_FreeString(ctx, xadd_params[j]);
+        }
+        sample_start += sizes[i];
+    }
+    RedisModule_Free(xadd_params);
+    return RedisModule_ReplyWithSimpleString(ctx, "OK");
+}
+
+int RedisModule_OnLoad(RedisModuleCtx *ctx) {
+    // Register the module itself
+    if (RedisModule_Init(ctx, "river", 1, REDISMODULE_APIVER_1) ==
+        REDISMODULE_ERR) {
+        return REDISMODULE_ERR;
+    }
+
+    // register example.hgetset - using the shortened utility registration macro
+    RMUtil_RegisterWriteCmd(ctx, "river.batch_xadd", BatchXaddCommand);
+    RMUtil_RegisterWriteCmd(ctx, "river.batch_xadd_variable", BatchXaddVariableCommand);
+
+    return REDISMODULE_OK;
+}

--- a/cpp/src/writer.h
+++ b/cpp/src/writer.h
@@ -11,7 +11,6 @@
 #include "redis.h"
 
 namespace river {
-
 class StreamWriterException : public std::exception {
  public:
     explicit StreamWriterException(const std::string& message) {
@@ -140,6 +139,7 @@ private:
     std::string stream_name_;
     int sample_size_;
     bool has_variable_width_field_;
+    bool has_module_installed_;
 
     int64_t total_samples_written_;
     bool is_stopped_;


### PR DESCRIPTION
- introduces a Redis server module, "river" (built in the redismodule subdirectory) that can be optionally installed into Redis to provide much improved throughput. It minimizes the number of bytes transmitted along the network by combining all existing XADD calls into a single call.
- If the module is installed, we also carefully avoid copies of the data to be sent, by manually managing the formatting of the Redis command and the sending via sockets.