### PR TITLE
Bug fixes for tail, seek for compressed flows

### DIFF
--- a/cpp/ingester/src/CMakeLists.txt
+++ b/cpp/ingester/src/CMakeLists.txt
@@ -16,7 +16,6 @@ endif()
 
 # ===== External Dependency: glog
 find_package(glog REQUIRED)
-
 find_package(Arrow REQUIRED)
 
 # This should work on Arrow 10.0+. Not Required though?

--- a/cpp/src/compression/compressor.h
+++ b/cpp/src/compression/compressor.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <cstdlib>
 #include <vector>
+#include <memory>
 #include "compressor_types.h"
 
 namespace river {
@@ -30,12 +31,23 @@ public:
      * absolute tolerance as specified
      */
     ZfpCompressor(int num_cols, double tolerance = -1);
-    ~ZfpCompressor() noexcept;
+    ~ZfpCompressor() noexcept override;
     std::vector<char> compress(const char *data, size_t length) override;
 private:
     ZfpCompressorImpl *impl_;
     int num_cols_;
     double tolerance_;
+};
+
+class DummyCompressor : public Compressor, public Decompressor {
+public:
+    ~DummyCompressor() override = default;
+    std::vector<char> compress(const char *data, size_t length) override {
+        return {data, data + length};
+    }
+    std::vector<char> decompress(const char *data, size_t length) override {
+        return {data, data + length};
+    }
 };
 
 std::unique_ptr<Decompressor> CreateDecompressor(const StreamCompression &compression);

--- a/cpp/src/compression/compressor_types.h
+++ b/cpp/src/compression/compressor_types.h
@@ -26,6 +26,7 @@ public:
         UNCOMPRESSED = 0,
         ZFP_LOSSLESS = 1,
         ZFP_LOSSY = 2,
+        DUMMY = 3,
     };
 
     explicit StreamCompression() : type_(Type::UNCOMPRESSED) {}
@@ -45,6 +46,7 @@ public:
             case Type::UNCOMPRESSED: return "UNCOMPRESSED";
             case Type::ZFP_LOSSLESS: return "ZFP_LOSSLESS";
             case Type::ZFP_LOSSY: return "ZFP_LOSSY";
+            case Type::DUMMY: return "DUMMY";
         }
         throw std::invalid_argument("Unhandled type");
     }
@@ -62,6 +64,8 @@ public:
             return StreamCompression(Type::ZFP_LOSSLESS, params);
         } else if (name == "ZFP_LOSSY") {
             return StreamCompression(Type::ZFP_LOSSY, params);
+        } else if (name == "DUMMY") {
+            return StreamCompression(Type::DUMMY, params);
         } else {
             throw std::invalid_argument("Unhandled type");
         }

--- a/cpp/src/reader.h
+++ b/cpp/src/reader.h
@@ -267,6 +267,7 @@ private:
 
     std::vector<char> lookahead_data_cache_;
     int64_t lookahead_data_cache_index_;
+    void ReloadLookaheadCache(const char *val_str, int val_str_len, const redisReply *values);
 
     std::vector<internal::StreamReaderListener *> listeners_;
 

--- a/cpp/src/redismodule/river_redismodule.c
+++ b/cpp/src/redismodule/river_redismodule.c
@@ -116,7 +116,7 @@ int BatchXaddCompressedCommand(RedisModuleCtx *ctx, RedisModuleString **argv, in
         xadd_params[2] = reference_str;
         xadd_params[3] = reference_id_str;
 
-        stream_add_resp = RedisModule_StreamAdd(key, REDISMODULE_STREAM_ADD_AUTOID, &reference_id, xadd_params, 2);
+        stream_add_resp = RedisModule_StreamAdd(key, REDISMODULE_STREAM_ADD_AUTOID, NULL, xadd_params, 2);
         if (stream_add_resp != REDISMODULE_OK) {
             return RedisModule_ReplyWithError(ctx, "ERR Xadd failed.");
         }

--- a/cpp/src/writer.cpp
+++ b/cpp/src/writer.cpp
@@ -217,7 +217,6 @@ void StreamWriter::WriteBytes(const char *data, int64_t num_samples, const int *
 
             // Placeholder vectors in case memory needs to be retained until sending
             std::vector<char> data_holder;
-            std::vector<int> sizes_holder;
 
             auto formatted_num_samples = fmt::format_int(samples_to_write_in_batch).str();
             if (has_compression) {
@@ -238,6 +237,8 @@ void StreamWriter::WriteBytes(const char *data, int64_t num_samples, const int *
                 append_argv[0] = "RIVER.batch_xadd_variable";
                 append_arglens[0] = strlen(append_argv[0]);
 
+                // TODO: we end up making a copy of sizes here instead of avoiding a copy like the data; we can
+                // improve this by making sizes zero-copy as well
                 append_argv[3] = (const char *) (&sizes[samples_written]);
                 append_arglens[3] = sizeof(int) * samples_to_write_in_batch;
 
@@ -273,7 +274,6 @@ void StreamWriter::WriteBytes(const char *data, int64_t num_samples, const int *
                 redis_->FormatCommandArgv(append_argc, append_argv.data(), append_arglens.data());
             RedisWriterCommand xadd_redis_command_(formatted_command_str);
 
-            // TODO: support sizes too to prevent copying sizes
             auto commands_to_send = xadd_redis_command_.ReplaceLastBulkStringAndAssemble(
                 data_to_write, data_to_write_num_bytes);
 


### PR DESCRIPTION
- Tail and seek weren't properly implemented for compressed flows
- Data promotion was incorrect, resulting in segfaults
- Adding DUMMY compressor for testing
- More exception handling in the StreamReader()
- Better integration tests to cover tail/seek